### PR TITLE
Ability to loop into resources

### DIFF
--- a/kubectl-grab_resources
+++ b/kubectl-grab_resources
@@ -56,35 +56,46 @@ function collect_resources {
         if [[ -z "${resource_name}" ]]; then
             continue
         fi
-        namespace=$(echo "${resource_name}" | awk -F ' ' '{print $1}')
-        name=$(echo "${resource_name}" | awk -F ' ' '{print $2}')
 
-        echo "---" >> "${OUTPUT_YAML}"
+        # converts result to an array, so we can loop
+        namespace=($(echo "${resource_name}" | awk -F ' ' '{print $1}'))
+        name=($(echo "${resource_name}" | awk -F ' ' '{print $2}'))
 
-        resource_output=$(kubectl get "${resource}" "${name}" -n "${namespace}" -o yaml 2> /dev/null)
-        if [[ $? != 0 ]]; then
-            continue
-        fi
+        for inner in ${!namespace[@]}
+        do
+            inner_namespace=${namespace[$inner]}
+            inner_name=${name[$inner]}
 
-        echo "${resource_output}" | kubectl neat >> "${OUTPUT_YAML}"
-        if [[ $? != 0 ]]; then
-            echo "error: cannot execute kubectl neat command.."
-            exit 1
-        fi
-        msg="Packed ${name} from ${resource}..."
+            cmd="kubectl get $resource ${inner_name} -o yaml"
+            # if namespace is <none> don't use it
+            if [ $inner_namespace = "<none>" ]; then
+                cmd="$cmd"
+            else
+                cmd="$cmd -n $namespace"
+            fi
 
-        if [ -z "${namespace}" ]
-        then
-            msg="${msg} namespace: ${namespace}"
-        fi
-        echo "${msg}"
+            echo "---" >> "${OUTPUT_YAML}"
+            $cmd 2>/dev/null | kubectl neat >> "${OUTPUT_YAML}"
+            if [[ $? != 0 ]]; then
+                echo "error: cannot execute kubectl neat command.."
+                exit 1
+            fi
 
-        if [ -z "${RESOURCE_FOUND}" ]
-        then
-            RESOURCE_FOUND="${resource}"
-        else
-            RESOURCE_FOUND="${RESOURCE_FOUND}, ${resource}"
-        fi
+            # display output to stdout
+            msg="Packed ${inner_name} from ${resource}..."
+            if [ -z "${inner_namespace}" ]
+            then
+                msg="${msg} namespace: ${inner_namespace}"
+            fi
+            echo "${msg}"
+
+            if [ -z "${RESOURCE_FOUND}" ]
+            then
+                RESOURCE_FOUND="${resource}"
+            else
+                RESOURCE_FOUND="${RESOURCE_FOUND}, ${resource}"
+            fi
+        done
     done
 }
 


### PR DESCRIPTION
This will allow inspecting into multiple resources sharing the same label

```bash
 ./kubectl-grab_resources "app.kubernetes.io/part-of=argocd"                                           11:52:49
Packed argocd-application-controller from clusterrole...
Packed argocd-server from clusterrole...
Packed argocd-application-controller from clusterrolebinding...
Packed argocd-server from clusterrolebinding...
Packed argocd-cm from configmap...
Packed argocd-gpg-keys-cm from configmap...
Packed argocd-rbac-cm from configmap...
Packed argocd-ssh-known-hosts-cm from configmap...
Packed argocd-tls-certs-cm from configmap...
Packed argocd-application-controller from deployment...
Packed argocd-dex-server from deployment...
Packed argocd-redis from deployment...
Packed argocd-repo-server from deployment...
Packed argocd-server from deployment...
Packed argocd-secret from secret...
Packed argocd-dex-server from service...
Packed argocd-metrics from service...
Packed argocd-redis from service...
Packed argocd-repo-server from service...
Packed argocd-server from service...
Packed argocd-server-metrics from service...
Packed argocd-application-controller from serviceaccount...
Packed argocd-dex-server from serviceaccount...
Packed argocd-server from serviceaccount...
Packed argocd-application-controller from customresourcedefinitions...
Packed argocd-application-controller from customresourcedefinitions...
Exported resources based on label app.kubernetes.io/part-of=argocd via output-kubectl-grab-resources-2020-09-25-11:52:58.yaml
```